### PR TITLE
Small build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ SET(LICENSECC_SHORT_LICENSE "BSD Software License")
 cmake_policy(SET CMP0048 NEW)
 project (lccgen
 	VERSION 2.0.0
-	DESCRIPTION "License generator for licensecc" 
 	LANGUAGES CXX)
+set(PROJECT_DESCRIPTION "License generator for licensecc")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/test/license_test.cpp
+++ b/test/license_test.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(extend_license) {
 }
 
 #else
-BOOST_AUTO_TEST_CASE(mock) { BOOST_CHECKPOINT("Mock test for older boost versions"); }
+BOOST_AUTO_TEST_CASE(mock) { BOOST_TEST_CHECKPOINT("Mock test for older boost versions"); }
 #endif
 }  // namespace test
 }  // namespace license


### PR DESCRIPTION
These are small build fixes to be able to build the project on Debian 9:

- use CMake PROJECT_DESCRIPTION var instead to be able to build with cmake < 3.8
- replace deprecated BOOST_CHECKPOINT with BOOST_TEST_CHECKPOINT
  (https://www.boost.org/doc/libs/1_35_0/libs/test/doc/components/test_tools/reference/deprecated.html)

