### PR TITLE
Publish header directory

### DIFF
--- a/src/license_generator/CMakeLists.txt
+++ b/src/license_generator/CMakeLists.txt
@@ -4,6 +4,10 @@ ADD_LIBRARY(license_generator_lib
 	STATIC command_line-parser.cpp license.cpp project.cpp ../ini/ConvertUTF.cpp
 	$<TARGET_OBJECTS:lcc_base> )
 
+target_include_directories(license_generator_lib PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 if(UNIX OR OPENSSL_FOUND)
 	target_link_libraries(license_generator_lib PUBLIC
 			     ${Boost_LIBRARIES} OpenSSL::Crypto ${EXTERNAL_LIBS} ${CMAKE_DL_LIBS})


### PR DESCRIPTION
Publishing the headers allows custom applications to wrap the license issuing within their own applications.
Otherwise, files like `license.hpp` cannot be included by downstream applications.

Maybe you have a better idea on how to allow this or I am not following the correct pattern, but to make my own license generator `myAppLicenseGenerator.exe`, I would like to link against the lcc-license-generator and just feed the API with my information to generate a license file.